### PR TITLE
feat(swift): emit @DocumentID on document-model structs

### DIFF
--- a/.changeset/swift-document-id.md
+++ b/.changeset/swift-document-id.md
@@ -2,4 +2,12 @@
 "typesync-cli": minor
 ---
 
-The Swift renderer now emits `@DocumentID var id: String?` and an `import FirebaseFirestore` for every `model: document` declaration, so callers can round-trip generated structs through Firestore's `Codable` SDK without threading the document ID separately. Alias structs are unaffected.
+**Breaking:** The Swift renderer now emits `@DocumentID var id: String?` and `import FirebaseFirestore` for every `model: document` declaration, so callers can round-trip generated structs through Firestore's `Codable` SDK without threading the document ID separately. Alias structs are unaffected.
+
+Existing consumers should expect:
+
+- The synthesized memberwise initializer of every document struct gains `id: String? = nil` as its first parameter; positional callers (rare) need to update.
+- Generated files now carry an `import FirebaseFirestore` line — projects must link `FirebaseFirestore` (or the legacy `FirebaseFirestoreSwift` for Firebase iOS SDK ≤10.x).
+- Decoding via `data(as: T.self)` now populates the `id` property from the snapshot's documentID; code that asserted on the absence of an `id` field will see the new value.
+- Under Swift 6 strict concurrency, the `@DocumentID` wrapper blocks automatic `Sendable` inference; users hitting this can declare their own `extension MyDoc: @unchecked Sendable {}`.
+- Any user-defined `extension MyDoc { var id: ... }` collides with the new property and must be removed.

--- a/.changeset/swift-document-id.md
+++ b/.changeset/swift-document-id.md
@@ -1,0 +1,5 @@
+---
+"typesync-cli": minor
+---
+
+The Swift renderer now emits `@DocumentID var id: String?` and an `import FirebaseFirestore` for every `model: document` declaration, so callers can round-trip generated structs through Firestore's `Codable` SDK without threading the document ID separately. Alias structs are unaffected.

--- a/src/generators/swift/__tests__/generate-swift.test.ts
+++ b/src/generators/swift/__tests__/generate-swift.test.ts
@@ -87,6 +87,7 @@ describe('SwiftGeneratorImpl', () => {
             ],
           },
           modelDocs: 'Represents a project within a workspace',
+          isDocumentModel: true,
         },
       ],
     };

--- a/src/generators/swift/_impl.ts
+++ b/src/generators/swift/_impl.ts
@@ -70,7 +70,7 @@ class SwiftGeneratorImpl implements SwiftGenerator {
 
   private createDeclarationForDocumentModel(model: schema.swift.DocumentModel): SwiftDeclaration {
     // A Firestore document can be considered an 'object' type
-    return this.createDeclarationForFlatObjectType(model.type, model.name, model.docs);
+    return this.createDeclarationForFlatObjectType(model.type, model.name, model.docs, true);
   }
 
   private createDeclarationForEnumType(
@@ -118,7 +118,8 @@ class SwiftGeneratorImpl implements SwiftGenerator {
   private createDeclarationForFlatObjectType(
     type: schema.swift.types.Object,
     modelName: string,
-    modelDocs: string | null
+    modelDocs: string | null,
+    isDocumentModel = false
   ): SwiftStructDeclaration {
     const literalProperties: swift.LiteralStructProperty[] = [];
     const regularProperties: swift.RegularStructProperty[] = [];
@@ -157,6 +158,7 @@ class SwiftGeneratorImpl implements SwiftGenerator {
       modelName,
       modelType: swiftType,
       modelDocs,
+      isDocumentModel,
     };
   }
 

--- a/src/generators/swift/_types.ts
+++ b/src/generators/swift/_types.ts
@@ -42,6 +42,13 @@ export interface SwiftStructDeclaration {
   modelName: string;
   modelType: swift.Struct;
   modelDocs: string | null;
+  /**
+   * True if this struct corresponds to a Firestore document model. The Swift
+   * renderer uses this to emit `@DocumentID var id: String?` so the generated
+   * type can round-trip through Firestore's `Codable` SDK without forcing
+   * consumers to thread the document ID through repository APIs separately.
+   */
+  isDocumentModel: boolean;
 }
 
 export type SwiftDeclaration =

--- a/src/renderers/swift/__tests__/__snapshots__/generate-swift.test.ts.snap
+++ b/src/renderers/swift/__tests__/__snapshots__/generate-swift.test.ts.snap
@@ -19,3 +19,17 @@ struct Project: Codable {
 ",
 }
 `;
+
+exports[`SwiftRendererImpl emits @DocumentID and the FirebaseFirestore import for document models 1`] = `
+{
+  "content": "import Foundation
+import FirebaseFirestore
+
+struct Project: Codable {
+    @DocumentID var id: String?
+    var name: String
+}
+
+",
+}
+`;

--- a/src/renderers/swift/__tests__/generate-swift.test.ts
+++ b/src/renderers/swift/__tests__/generate-swift.test.ts
@@ -49,6 +49,42 @@ describe('SwiftRendererImpl', () => {
             ],
           },
           modelDocs: 'A project within a workspace',
+          isDocumentModel: false,
+        },
+      ],
+    };
+
+    const result = await renderer.render(generation);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('emits @DocumentID and the FirebaseFirestore import for document models', async () => {
+    const renderer = createSwiftRenderer({
+      indentation: 4,
+      target: 'firebase@10',
+    });
+
+    const generation: SwiftGeneration = {
+      type: 'swift',
+      declarations: [
+        {
+          type: 'struct',
+          modelName: 'Project',
+          modelType: {
+            type: 'struct',
+            literalProperties: [],
+            regularProperties: [
+              {
+                type: { type: 'string' },
+                originalName: 'name',
+                optional: false,
+                docs: null,
+              },
+            ],
+          },
+          modelDocs: null,
+          isDocumentModel: true,
         },
       ],
     };

--- a/src/renderers/swift/_impl.ts
+++ b/src/renderers/swift/_impl.ts
@@ -26,7 +26,8 @@ class SwiftRendererImpl implements SwiftRenderer {
   public async render(g: SwiftGeneration): Promise<RenderedFile> {
     const b = new StringBuilder();
 
-    b.append(`${this.generateImportStatements()}\n\n`);
+    const hasDocumentModel = g.declarations.some(d => d.type === 'struct' && d.isDocumentModel);
+    b.append(`${this.generateImportStatements(hasDocumentModel)}\n\n`);
 
     g.declarations.forEach(declaration => {
       b.append(`${this.renderDeclaration(declaration)}\n\n`);
@@ -39,9 +40,15 @@ class SwiftRendererImpl implements SwiftRenderer {
     return rootFile;
   }
 
-  private generateImportStatements() {
+  private generateImportStatements(hasDocumentModel: boolean) {
     const b = new StringBuilder();
     b.append(`import Foundation`);
+    if (hasDocumentModel) {
+      // FirebaseFirestore exports the @DocumentID property wrapper used on
+      // document-model structs to bind the Firestore document ID to a Codable
+      // property without writing it into the document body.
+      b.append(`\nimport FirebaseFirestore`);
+    }
     return b.toString();
   }
 
@@ -250,6 +257,9 @@ class SwiftRendererImpl implements SwiftRenderer {
       b.append(this.buildDocCommentsFromMarkdownDocs(modelDocs) + '\n');
     }
     b.append(`struct ${modelName}: ${conformedProtocolsAsString} {` + '\n');
+    if (declaration.isDocumentModel) {
+      b.append(`${this.indent(1)}@DocumentID var id: String?` + '\n');
+    }
     modelType.literalProperties.forEach(property => {
       const expression = swift.expressionForType(property.type);
       if (property.docs !== null) {


### PR DESCRIPTION
Closes #206.

## What

- Adds `isDocumentModel: boolean` to `SwiftStructDeclaration`. Set `true` only for `model: document` declarations, `false` for alias-derived object structs.
- Renderer emits `@DocumentID var id: String?` as the first property of each document struct and adds `import FirebaseFirestore` when any document model is present.
- New renderer test case + snapshot covering the document-model path. The existing alias-only snapshot is unchanged because that test uses `isDocumentModel: false`.
- Updates the existing generator test to assert `isDocumentModel: true` on the `Project` document model.
- Adds a `minor` changeset.

## Why

Generated document structs cannot round-trip through Firestore's `Codable` SDK without callers maintaining a parallel ID alongside the model — see #206 for the workaround survey.

## Notes for reviewers

- The patch defaults to emitting `@DocumentID`. Reasoning: `--target firebase@10` already pulls in the Firestore SDK, so `import FirebaseFirestore` adds no fresh dependency. Happy to flip to opt-in (e.g. `--with-document-id` flag) if preferred — let me know in review.
- TypeScript and Python generators are intentionally out of scope. `firestore.DocumentSnapshot` exposes `.id` directly in TS; there's no Codable-equivalent pressure that motivates a parallel change. Easy to add later if maintainers want symmetry.
- I haven't run `tests/security/rules.test.ts` end-to-end (it needs the Firebase emulator); only `src/generators/swift` and `src/renderers/swift` are exercised locally. CI should cover the rest.